### PR TITLE
fix unflatten error when missing parent key

### DIFF
--- a/flatten_json/__init__.py
+++ b/flatten_json/__init__.py
@@ -377,7 +377,11 @@ def unflatten(flat_dict, separator='_'):
 
     def _unflatten(dic, keys, value):
         for key in keys[:-1]:
-            dic = dic.setdefault(key, {})
+            nested_dic = dic.get(key)
+            if nested_dic is None:
+                nested_dic = {}
+                dic[key] = nested_dic
+            dic = nested_dic
 
         dic[keys[-1]] = value
 


### PR DESCRIPTION
### Summary
When unflatten with the following test data, an exception was raised: `'NoneType' object has no attribute 'setdefault'`

```python
from flatten_json import unflatten_list

test_dic = {
'header': None, 
'header.errcode': 0, 
'header.errmsg': '', 
'term_group': None, 
'term_group.contents': None, 
'term_group.group_id': 'USER_TERM_GROUP_NONE', 
'term_group.login_config': None, 
'term_group.login_config.check_boxes': None, 
'term_group.terms': None, 
'term_group.terms.0.contents': None  # missing parent key 'term_group.terms.0'
}

unflatten_list(test_dic, '.')
```


### Bug Fixes/New Features
* fixed the above error.

### How to Verify
Use the above test data.